### PR TITLE
Added the hasmarkup attribute to mock TerminalReporter.

### DIFF
--- a/pytest_tldr.py
+++ b/pytest_tldr.py
@@ -59,6 +59,7 @@ class TLDRReporter:
 
         self.verbosity = self.config.option.verbose
         self.xdist = getattr(self.config.option, 'numprocesses', None) is not None
+        self.hasmarkup = False
 
         self.stats = {}
 


### PR DESCRIPTION
Not sure when it was added, but xdist (and other plugins) need it.