### PR TITLE
Fixed #28 - Corrected output stream flush handling.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.5]
+        python-version: [3.6]
         pytest-version: ['<4', '<5', '<6', '>=6.0.0']
     steps:
     - uses: actions/checkout@v1
@@ -64,7 +64,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         pytest-version: ['<4', '<5', '<6', '>=6.0.0']
     steps:
     - uses: actions/checkout@v1

--- a/changes/28.bugfix.rst
+++ b/changes/28.bugfix.rst
@@ -1,0 +1,2 @@
+Corrected output stream flush handling. This prevented long-running test results
+from being displayed until the end of the test suite.

--- a/pytest_tldr.py
+++ b/pytest_tldr.py
@@ -114,15 +114,9 @@ class TLDRReporter:
 
     def print(self, text='', **kwargs):
         end = kwargs.pop('end', '\n')
-        if sys.version_info.major == 2:
-            # Python 2.7 doesn't accept the flush kwarg.
-            flush = kwargs.pop('flush', False)
-            self._tw.write(text)
-            if flush:
-                self.file.flush()
-        else:
-            self._tw.write(text)
-        self._tw.write(end)
+        flush = kwargs.pop('flush', False)
+        self._tw.write(text, flush=flush)
+        self._tw.write(end, flush=flush)
 
     def pytest_internalerror(self, excrepr):
         for line in str(excrepr).split("\n"):

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,10 +16,10 @@ classifiers =
     Topic :: Software Development :: Testing
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
@@ -38,13 +38,13 @@ keywords = pytest
 
 [project_urls]
 Funding = https://beeware.org/contributing/membership/
-# Documentation = https://toga.readthedocs.io/
+# Documentation = https://pytest-tldr.readthedocs.io/
 Tracker = https://github.com/freakboy3742/pytest-tldr/issues
 Source = https://github.com/freakboy3742/pytest-tldr
 
 [options]
 zip_safe = False
-python_requires = !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*
+python_requires = >= 3.6
 install_requires =
     pytest >= 3.5.0
 py_modules =

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8,check-manifest,towncrier-check,package,py{35,36,37,38}
+envlist = flake8,check-manifest,towncrier-check,package,py{36,37,38,39}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Ensure that the TerminalWriter is flushed whenever a write occurs. 

This removes some vestigial Python 2 support, as well as formally deprecating Python 3.5, and adding Python 3.9.