### PR TITLE
Fixes #32 - Restore pytest<6 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         python -m pip install tox
     - name: Test
       run: |
-        tox -e py${{ matrix.python-version }}-${{ matrix.pytest-version }}
+        tox -e py${{ matrix.python-version }}-pytest${{ matrix.pytest-version }}
 
   build:
     needs: smoke
@@ -76,4 +76,4 @@ jobs:
         python -m pip install tox
     - name: Test
       run: |
-        tox -e py${{ matrix.python-version }}-${{ matrix.pytest-version }}
+        tox -e py${{ matrix.python-version }}-pytest${{ matrix.pytest-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,11 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6]
+        tox-python-version: ['py36']
         pytest-version: ['3', '4', '5', '6']
+        include:
+          - tox-python-version: 'py36'
+            python-version: [3.6]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -53,7 +56,7 @@ jobs:
         python -m pip install tox
     - name: Test
       run: |
-        tox -e py${{ matrix.python-version.replace('.', '') }}-pytest${{ matrix.pytest-version }}
+        tox -e ${{ matrix.tox-python-version }}-pytest${{ matrix.pytest-version }}
 
   build:
     needs: smoke
@@ -61,8 +64,15 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        tox-python-version: ['py37', 'py38', 'py39']
         pytest-version: ['3', '4', '5', '6']
+        include:
+          - tox-python-version: 'py37'
+            python-version: 3.7
+          - tox-python-version: 'py38'
+            python-version: 3.8
+          - tox-python-version: 'py39'
+            python-version: 3.9
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -76,4 +86,4 @@ jobs:
         python -m pip install tox
     - name: Test
       run: |
-        tox -e py${{ matrix.python-version.replace('.', '') }}-pytest${{ matrix.pytest-version }}
+        tox -e ${{ matrix.tox-python-version }}-pytest${{ matrix.pytest-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         pytest-version: ['3', '4', '5', '6']
         include:
           - tox-python-version: 'py36'
-            python-version: [3.6]
+            python-version: 3.6
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
         python -m pip install tox
     - name: Test
       run: |
-        tox -e py${{ matrix.python-version }}-pytest${{ matrix.pytest-version }}
+        tox -e py${{ matrix.python-version.replace('.', '') }}-pytest${{ matrix.pytest-version }}
 
   build:
     needs: smoke
@@ -76,4 +76,4 @@ jobs:
         python -m pip install tox
     - name: Test
       run: |
-        tox -e py${{ matrix.python-version }}-pytest${{ matrix.pytest-version }}
+        tox -e py${{ matrix.python-version.replace('.', '') }}-pytest${{ matrix.pytest-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.6]
-        pytest-version: ['<4', '<5', '<6', '>=6.0.0']
+        pytest-version: ['3', '4', '5', '6']
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -51,12 +51,9 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools
         python -m pip install tox
-        # Ensure a specific version of pytest
-        python -m pip install "pytest${{ matrix.pytest-version }}"
-        python -m pip install -e .
     - name: Test
       run: |
-        tox -e py
+        tox -e py${{ matrix.python-version }}-${{ matrix.pytest-version }}
 
   build:
     needs: smoke
@@ -65,7 +62,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: [3.7, 3.8, 3.9]
-        pytest-version: ['<4', '<5', '<6', '>=6.0.0']
+        pytest-version: ['3', '4', '5', '6']
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -77,9 +74,6 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install --upgrade setuptools
         python -m pip install tox
-        # Ensure a specific version of pytest
-        python -m pip install "pytest${{ matrix.pytest-version }}"
-        python -m pip install -e .
     - name: Test
       run: |
-        tox -e py
+        tox -e py${{ matrix.python-version }}-${{ matrix.pytest-version }}

--- a/changes/32.bugfix.rst
+++ b/changes/32.bugfix.rst
@@ -1,0 +1,1 @@
+Restored compatibility with pytest < 6.

--- a/pytest_tldr.py
+++ b/pytest_tldr.py
@@ -114,9 +114,18 @@ class TLDRReporter:
 
     def print(self, text='', **kwargs):
         end = kwargs.pop('end', '\n')
-        flush = kwargs.pop('flush', False)
-        self._tw.write(text, flush=flush)
-        self._tw.write(end, flush=flush)
+
+        self._tw.write(text)
+        self._tw.write(end)
+        try:
+            if kwargs.pop('flush', False):
+                self._tw.flush()
+        except AttributeError:
+            # pytest 6 introduced a separate flush argument to
+            # TerminalWriter.write(), and a standalone TerminalWriter.flush()
+            # method. This argument/method didn't exist on pytest 5 and lower;
+            # the flush was made implicitly on every write.
+            pass
 
     def pytest_internalerror(self, excrepr):
         for line in str(excrepr).split("\n"):

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,15 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8,check-manifest,towncrier-check,package,py{36,37,38,39}
+envlist = flake8,check-manifest,towncrier-check,package,py{36,37,38,39}-pytest{3,4,5,6}
 skip_missing_interpreters = true
 
 [testenv]
 deps =
-    pytest
+    pytest3: pytest < 4
+    pytest4: pytest < 5
+    pytest5: pytest < 6
+    pytest6: pytest >= 6.0.0
     pytest-cov
     pytest-tldr
 commands =


### PR DESCRIPTION
The 0.2.3 release added a `flush` argument to TerminalWriter calls to force console output; however, that option wasn't available in pytest<6. 

This wasn't picked up in CI due to a misconfiguration of the test environment.