### PR TITLE
Correct incompatibility with PyTest 7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,36 +38,24 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tox-python-version: ['py37', 'py38', 'py39', 'py310', 'py311'] #, 'py312']
-        pytest-version: ['3', '4', '5', '6', '7']
-        include:
-          - tox-python-version: 'py37'
-            python-version: "3.7"
-          - tox-python-version: 'py38'
-            python-version: "3.8"
-          - tox-python-version: 'py39'
-            python-version: "3.9"
-          - tox-python-version: 'py310'
-            python-version: "3.10"
-          - tox-python-version: 'py311'
-            python-version: "3.11"
-          # - tox-python-version: 'py312'
-          #   python-version: "3.12.0-alpha - 3.12.0"
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        pytest-version: ["3", "4", "5", "6", "7"]
 
         exclude:
-          - tox-python-version: py310
-          - pytest-version: 3
-          - tox-python-version: py310
-          - pytest-version: 4
-          - tox-python-version: py310
-          - pytest-version: 5
+          # PyTest <=5 doesn't work on Python >= 3.10
+          - python-version: "3.10"
+            pytest-version: "3"
+          - python-version: "3.10"
+            pytest-version: "4"
+          - python-version: "3.10"
+            pytest-version: "5"
 
-          - tox-python-version: py311
-          - pytest-version: 3
-          - tox-python-version: py311
-          - pytest-version: 4
-          - tox-python-version: py311
-          - pytest-version: 5
+          - python-version: "3.11"
+            pytest-version: "3"
+          - python-version: "3.11"
+            pytest-version: "4"
+          - python-version: "3.11"
+            pytest-version: "5"
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -81,4 +69,5 @@ jobs:
         python -m pip install tox
     - name: Test
       run: |
-        tox -e ${{ matrix.tox-python-version }}-pytest${{ matrix.pytest-version }}
+        export PY_VERSION=${{ matrix.python-version }}
+        tox -e py${PY_VERSION/./}-pytest${{ matrix.pytest-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,11 @@ jobs:
         - 'towncrier-check'
         - 'package'
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3.1.0
+      with:
+        fetch-depth: 0
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4.3.0
       with:
         python-version: '3.X'
     - name: Install dependencies
@@ -54,7 +56,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4.3.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tox-python-version: ['py37', 'py38', 'py39', 'py310', 'py311', 'py312']
+        tox-python-version: ['py37', 'py38', 'py39', 'py310', 'py311'] #, 'py312']
         pytest-version: ['3', '4', '5', '6', '7']
         include:
           - tox-python-version: 'py37'
@@ -51,8 +51,8 @@ jobs:
             python-version: "3.10"
           - tox-python-version: 'py311'
             python-version: "3.11"
-          - tox-python-version: 'py312'
-            python-version: "3.12.0-alpha - 3.12.0"
+          # - tox-python-version: 'py312'
+          #   python-version: "3.12.0-alpha - 3.12.0"
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,47 +32,27 @@ jobs:
       run: |
         tox -e ${{ matrix.task }}
 
-  smoke:
+  build:
     needs: beefore
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
       matrix:
-        tox-python-version: ['py36']
-        pytest-version: ['3', '4', '5', '6']
-        include:
-          - tox-python-version: 'py36'
-            python-version: 3.6
-    steps:
-    - uses: actions/checkout@v1
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install --upgrade setuptools
-        python -m pip install tox
-    - name: Test
-      run: |
-        tox -e ${{ matrix.tox-python-version }}-pytest${{ matrix.pytest-version }}
-
-  build:
-    needs: smoke
-    runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 4
-      matrix:
-        tox-python-version: ['py37', 'py38', 'py39']
-        pytest-version: ['3', '4', '5', '6']
+        tox-python-version: ['py37', 'py38', 'py39', 'py310', 'py311', 'py312']
+        pytest-version: ['3', '4', '5', '6', '7']
         include:
           - tox-python-version: 'py37'
-            python-version: 3.7
+            python-version: "3.7"
           - tox-python-version: 'py38'
-            python-version: 3.8
+            python-version: "3.8"
           - tox-python-version: 'py39'
-            python-version: 3.9
+            python-version: "3.9"
+          - tox-python-version: 'py310'
+            python-version: "3.10"
+          - tox-python-version: 'py311'
+            python-version: "3.11"
+          - tox-python-version: 'py312'
+            python-version: "3.12.0-alpha - 3.12.0"
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,21 @@ jobs:
             python-version: "3.11"
           # - tox-python-version: 'py312'
           #   python-version: "3.12.0-alpha - 3.12.0"
+
+        exclude:
+          - tox-python-version: py310
+          - pytest-version: 3
+          - tox-python-version: py310
+          - pytest-version: 4
+          - tox-python-version: py310
+          - pytest-version: 5
+
+          - tox-python-version: py311
+          - pytest-version: 3
+          - tox-python-version: py311
+          - pytest-version: 4
+          - tox-python-version: py311
+          - pytest-version: 5
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,13 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   beefore:
     name: Pre-test checks
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
       matrix:
         task:
         - 'flake8'
@@ -36,7 +35,6 @@ jobs:
     needs: beefore
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
       matrix:
         tox-python-version: ['py37', 'py38', 'py39', 'py310', 'py311', 'py312']
         pytest-version: ['3', '4', '5', '6', '7']

--- a/changes/36.bugfix.rst
+++ b/changes/36.bugfix.rst
@@ -1,0 +1,1 @@
+An incompatibility with Pytest 7.2 was corrected.

--- a/changes/template.rst
+++ b/changes/template.rst
@@ -1,7 +1,9 @@
 {% for section, _ in sections.items() %}
 {% set underline = underlines[0] %}{% if section %}{{section}}
 {{ underline * section|length }}{% set underline = underlines[1] %}
+
 {% endif %}
+
 {% if sections[section] %}
 {% for category, val in definitions.items() if category in sections[section]%}
 {{ definitions[category]['name'] }}
@@ -10,16 +12,18 @@
 {% if definitions[category]['showcontent'] %}
 {% for text, values in sections[section][category].items() %}
 * {{ text }} ({{ values|join(', ') }})
-
 {% endfor %}
+
 {% else %}
 * {{ sections[section][category]['']|join(', ') }}
+
 {% endif %}
 {% if sections[section][category]|length == 0 %}
 No significant changes.
 
 {% else %}
 {% endif %}
+
 {% endfor %}
 {% else %}
 No significant changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,4 @@ directory = "changes"
 package = "pytest_tldr"
 filename = "CHANGELOG.rst"
 title_format = "{version} ({project_date})"
-issue_format = "`#{issue} <https://github.com/freakboy3742/pytest-tldr/issues/{issue}>`_"
 template = "changes/template.rst"
-underlines = ["-", "^", "\""]

--- a/pytest_tldr.py
+++ b/pytest_tldr.py
@@ -152,7 +152,12 @@ class TLDRReporter:
                 msg += "[pypy-{}-{}]".format(verinfo, sys.pypy_version_info[3])
             self.print(msg)
             self.print("pytest=={}".format(pytest.__version__))
-            self.print("py=={}".format(py.__version__))
+            try:
+                # Pytest 7.2 vendored `py`; if it's vendored, the version
+                # won't exist, but we also don't care that it doesn't exist.
+                self.print("py=={}".format(py.__version__))
+            except AttributeError:
+                pass
             self.print("pluggy=={}".format(pluggy.__version__))
 
             headers = self.config.hook.pytest_report_header(

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,8 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = flake8,check-manifest,towncrier-check,package,py{36,37,38,39}-pytest{3,4,5,6}
+envlist = flake8,check-manifest,towncrier-check,package,py{37,38,39,310,311,312}-pytest{3,4,5,6,7}
 skip_missing_interpreters = true
 
 [testenv]
@@ -12,7 +12,8 @@ deps =
     pytest3: pytest < 4
     pytest4: pytest < 5
     pytest5: pytest < 6
-    pytest6: pytest >= 6.0.0
+    pytest6: pytest < 7
+    pytest7: pytest >= 6.0.0
     pytest-cov
     pytest-tldr
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -35,14 +35,14 @@ commands =
 [testenv:towncrier-check]
 skip_install = True
 deps =
-    towncrier >= 18.5.0
+    towncrier ~= 22.8
 commands =
    python -m towncrier.check
 
 [testenv:towncrier]
 skip_install = True
 deps =
-    towncrier >= 18.5.0
+    towncrier ~= 22.8
 commands =
     towncrier {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ skip_install = True
 deps =
     towncrier ~= 22.8
 commands =
-   python -m towncrier.check
+   python -m towncrier.check --compare-with origin/main
 
 [testenv:towncrier]
 skip_install = True


### PR DESCRIPTION
Pytest 7.2 vendored the `py` library; as such, we don't need to include the version of `py` in verbose debugging output.

Fixes #35.