### PR TITLE
Use pathlib.Path instead of py.path.local() for pytest_report_header hook

### DIFF
--- a/changes/51.bugfix.md
+++ b/changes/51.bugfix.md
@@ -1,1 +1,0 @@
-The `start_path` argument passed to the `pytest_report_header` hook is now a `pathlib.Path`, matching pytest's own hook specification, instead of a deprecated `py.path.local` object.

--- a/changes/51.bugfix.md
+++ b/changes/51.bugfix.md
@@ -1,0 +1,1 @@
+The `start_path` argument passed to the `pytest_report_header` hook is now a `pathlib.Path`, matching pytest's own hook specification, instead of a deprecated `py.path.local` object.

--- a/changes/51.misc.md
+++ b/changes/51.misc.md
@@ -1,0 +1,1 @@
+The `start_path` argument passed to the `pytest_report_header` hook has been updated to match current pytest usage.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,10 +108,6 @@ ignore = [
     "SIM108",  # replace if-else with ternary operator (too opinionated)
 ]
 
-[tool.ruff.lint.per-file-ignores]
-# Ignores needed to pass the Ruff 0.16 update.
-"pytest_tldr.py" = ["PTH124"]
-
 [tool.setuptools]
 py-modules = ["pytest_tldr"]
 

--- a/pytest_tldr.py
+++ b/pytest_tldr.py
@@ -146,7 +146,7 @@ class TLDRReporter:
             self.print(f"pluggy=={pluggy.__version__}")
 
             headers = self.config.hook.pytest_report_header(
-                config=self.config, start_path=py.path.local()
+                config=self.config, start_path=self.config.invocation_params.dir
             )
             for header in headers:
                 if isinstance(header, str):


### PR DESCRIPTION
`start_path` has been a `pathlib.Path` since pytest 7.0, replacing the deprecated `startdir` (`py.path.local`) parameter that was removed in pytest 9.0.

The `startdir` -> `start_path` kwarg rename happened in #39 ("Adapt to API deprecation in pytest 9.x"), but the value being passed wasn't updated to match - it kept using `py.path.local()` instead of switching to a real `Path`.

This PR replaces `py.path.local()` with `self.config.invocation_params.dir`, which is the exact same value pytest's own `TerminalReporter` uses for this purpose (see `self.startpath = config.invocation_params.dir` in `_pytest/terminal.py`).

With this change, `pytest_tldr.py` no longer triggers `PTH124`, so the per-file ignore added in #50 has been removed from `pyproject.toml`.
